### PR TITLE
Separate webpack configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "dev": "webpack --watch",
-    "build": "webpack --mode production"
+    "dev": "webpack --watch --config webpack.dev.ts",
+    "build": "webpack --config webpack.prod.ts"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.240",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -2,55 +2,50 @@ import type { Configuration } from 'webpack';
 import path from 'path';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 
-const config = (): Configuration => {
-  return {
-    mode: 'development',
-    entry: {
-      content_scripts: path.join(__dirname, 'src', 'contentScripts', 'main.ts'),
-      background: path.join(__dirname, 'src', 'background', 'main.ts'),
-      options: path.join(__dirname, 'src', 'options', 'index.tsx'),
-      popup: path.join(__dirname, 'src', 'popup', 'index.tsx'),
-    },
-    output: {
-      path: path.join(__dirname, 'dist'),
-      filename: '[name].js',
-    },
-    module: {
-      rules: [
-        {
-          test: /.tsx?$/,
-          use: 'ts-loader',
-          exclude: '/node_modules/',
-        },
-        {
-          exclude: /node_modules/,
-          test: /\.scss$/,
-          use: [
-            {
-              loader: 'style-loader', // Creates style nodes from JS strings
-            },
-            {
-              loader: 'css-loader', // Translates CSS into CommonJS
-            },
-            {
-              loader: 'sass-loader', // Compiles Sass to CSS
-            },
-          ],
-        },
-      ],
-    },
-    resolve: {
-      alias: {
-        '~': path.resolve(__dirname, 'src'),
+export const config: Configuration = {
+  entry: {
+    content_scripts: path.join(__dirname, 'src', 'contentScripts', 'main.ts'),
+    background: path.join(__dirname, 'src', 'background', 'main.ts'),
+    options: path.join(__dirname, 'src', 'options', 'index.tsx'),
+    popup: path.join(__dirname, 'src', 'popup', 'index.tsx'),
+  },
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: '[name].js',
+  },
+  module: {
+    rules: [
+      {
+        test: /.tsx?$/,
+        use: 'ts-loader',
+        exclude: '/node_modules/',
       },
-      extensions: ['.ts', '.tsx', '.js'],
-    },
-    plugins: [
-      new CopyWebpackPlugin({
-        patterns: [{ from: 'public', to: '.' }],
-      }),
+      {
+        exclude: /node_modules/,
+        test: /\.scss$/,
+        use: [
+          {
+            loader: 'style-loader', // Creates style nodes from JS strings
+          },
+          {
+            loader: 'css-loader', // Translates CSS into CommonJS
+          },
+          {
+            loader: 'sass-loader', // Compiles Sass to CSS
+          },
+        ],
+      },
     ],
-  };
+  },
+  resolve: {
+    alias: {
+      '~': path.resolve(__dirname, 'src'),
+    },
+    extensions: ['.ts', '.tsx', '.js'],
+  },
+  plugins: [
+    new CopyWebpackPlugin({
+      patterns: [{ from: 'public', to: '.' }],
+    }),
+  ],
 };
-
-export default config;

--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -1,0 +1,10 @@
+import type { Configuration } from 'webpack';
+import { config } from './webpack.config';
+
+export default (): Configuration => {
+  return {
+    mode: 'development',
+    devtool: 'inline-source-map',
+    ...config,
+  };
+};

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -1,0 +1,9 @@
+import type { Configuration } from 'webpack';
+import { config } from './webpack.config';
+
+export default (): Configuration => {
+  return {
+    mode: 'production',
+    ...config,
+  };
+};


### PR DESCRIPTION
Using `webpack.config.ts` in development mode generates codes with `eval`, which is forbidden by Chrome extension.
Using `devtools` config avoids this behaviour.